### PR TITLE
optional awsKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,26 @@ Installation
 -------------
 I use namespace `monitoring`, but this is optional.
 
-### Creating the secret. 
-Is necessary getting AWS Key and Secret.
+### AWS Permissions
+
+The following AWS policy is needed to use this program:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Id": "SQSTiamat",
+    "Statement": [
+        {
+            "Sid": "SQSTiamat",
+            "Effect": "Allow",
+            "Action": "sqs:GetQueueAttributes",
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+If the program is running outside AWS and you don't have any configured credentials in the instance environment, you can set an AWS key and secret this way:
 
 ```shell
 $ read awskey
@@ -29,20 +47,10 @@ $ read awssecret
 $ kubectl -n monitoring create secret generic aws-tiamat --from-literal=key=$awskey --from-literal=secret=$awssecret
 ```
 
-AWS Policy:
-```json
-{
-    "Version": "2012-10-17",
-    "Id": "SQSTiamat",
-    "Statement": [
-        {
-            "Sid": "SQSTiamat",
-            "Effect": "Allow",
-            "Action": "sqs:GetQueueAttributes",
-            "Resource": "*"
-        }
-    ]
-}
+If the program is running inside an instance that already has an IAM role attached and you don't want to use explicit credentials, set the key and secret as empty by running:
+
+```shell
+$ kubectl -n monitoring create secret generic aws-tiamat --from-literal=key="" --from-literal=secret=""
 ```
 
 ### Creating configMap.

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -13,7 +13,15 @@ type AWS struct {
 }
 
 func (a *AWS) newConfig() *aws.Config {
-	return aws.NewConfig().WithCredentials(
-		credentials.NewStaticCredentials(a.key, a.secret, ""),
-	).WithRegion(a.region)
+	var config *aws.Config
+
+	if a.key == "" {
+		config = aws.NewConfig()
+	} else {
+		config = aws.NewConfig().WithCredentials(
+			credentials.NewStaticCredentials(a.key, a.secret, ""),
+		)
+	}
+
+	return config.WithRegion(a.region)
 }

--- a/main.go
+++ b/main.go
@@ -64,8 +64,9 @@ func main() {
 	logsEnabled := configStruct.LogsEnabled
 
 	// Test empty confs variables
-	checkEmptyVariable("secret AWSKEY", awsKey)
-	checkEmptyVariable("secret AWSSECRET", awsSecret)
+	if awsKey != "" {
+		checkEmptyVariable("secret AWSSECRET", awsSecret)
+	}
 	checkEmptyVariable("configMap value: region", awsRegion)
 	checkEmptyVariable("configMap value: interval", strconv.Itoa(interval))
 	checkEmptyVariable("configMap value: metric_type", metricType)


### PR DESCRIPTION
When the program is running inside an EC2 instance that already has an IAM role attached to it, it doesn't need a key/secret because the AWS Go SDK will fetch the credentials from the IAM role automatically.

To maintain most of the code compatibility, if the AWSKEY environment variable isn't set (or is empty), we initialize the configuration without providing any credentials - thus letting the SDK decide how to fetch them.